### PR TITLE
Added pycharm project settings

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -120,6 +120,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# PyCharm project settings
+.idea
+
 # mkdocs documentation
 /site
 


### PR DESCRIPTION
**Reasons for making this change:**

pycharm is a widely popular used python IDE so it's project settings should be included in the gitignore

